### PR TITLE
Ignore Factorio in-game command line / commands

### DIFF
--- a/factorio-plugin/command-line.lua
+++ b/factorio-plugin/command-line.lua
@@ -1,0 +1,48 @@
+--##
+
+local util = require("factorio-plugin.util")
+
+---@param uri string @ The uri of file
+---@param text string @ The content of file
+---@param diffs Diff[] @ The diffs to add more diffs to
+local function replace(uri, text, diffs)
+  -- Remove the `/sc ` completely and replace with blank space.
+  ---@type string|number
+  for s_remove, s_id
+  in
+    text:gmatch("()/silent-command ()")
+  do
+    util.add_diff(diffs, s_remove, s_id, string.rep(" ", s_id - s_remove))
+  end
+  
+  -- Remove the `/sc ` completely and replace with blank space.
+  ---@type string|number
+  for s_remove, s_id
+  in
+    text:gmatch("()/sc ()")
+  do
+    util.add_diff(diffs, s_remove, s_id, string.rep(" ", s_id - s_remove))
+  end
+  
+  -- Remove the `/command ` completely and replace with blank space.
+  ---@type string|number
+  for s_remove, s_id
+  in
+    text:gmatch("()/command ()")
+  do
+    util.add_diff(diffs, s_remove, s_id, string.rep(" ", s_id - s_remove))
+  end
+  
+  -- Remove the `/c ` completely and replace with blank space.
+  ---@type string|number
+  for s_remove, s_id
+  in
+    text:gmatch("()/c ()")
+  do
+    util.add_diff(diffs, s_remove, s_id, string.rep(" ", s_id - s_remove))
+  end
+end
+
+return {
+  replace = replace,
+}

--- a/plugin.lua
+++ b/plugin.lua
@@ -22,6 +22,7 @@ local require_module = require("factorio-plugin.require")
 local global = require("factorio-plugin.global")
 local remote = require("factorio-plugin.remote")
 local on_event = require("factorio-plugin.on-event")
+local command_line = require("factorio-plugin.command-line")
 
 ---@class Diff
 ---@field start integer @ The number of bytes at the beginning of the replacement
@@ -79,6 +80,7 @@ function OnSetText(uri, text)
   global.replace(uri, text, diffs)
   remote.replace(uri, text, diffs)
   on_event.replace(uri, text, diffs)
+  command_line.replace(uri, text, diffs)
 
   diffs.count = nil
   return diffs


### PR DESCRIPTION
Ignore like `/command` and `/sc` strings as Sumneko doesn't need to consider them, but shouldn't error on them. Useful for when dealing with Lua code snippets for command/RCON usage.